### PR TITLE
Add Windows package for 5.1.0~beta1

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.5.1.0~beta1+options+win/files/ocaml-variants.install
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0~beta1+options+win/files/ocaml-variants.install
@@ -1,0 +1,1 @@
+share_root: ["config.cache" {"ocaml/config.cache"}]

--- a/packages/ocaml-variants/ocaml-variants.5.1.0~beta1+options+win/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0~beta1+options+win/opam
@@ -1,0 +1,122 @@
+opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "First beta release of OCaml 5.1.0, configured for Windows"
+maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#5.1"
+depends: [
+  "ocaml" {= "5.1.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "base-domains" {post}
+  "base-nnp" {post}
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv" }
+  "conf-flexdll" {os = "cygwin"}
+  ("flexdll" {os = "win32"} | "flexdll-bin" {os = "win32"} & "flexlink" {os = "win32" & post})
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build-env: [
+  [PATH += "%{lib}%/%{flexdll-bin:installed?flexdll-bin:ocaml}%"]
+  [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+  [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+]
+build: [
+  [
+    # General configuration
+    "./configure" "-C" "--prefix=%{prefix}%" "--docdir=%{doc}%/ocaml"
+
+    # Windows-specific configuration
+    "--with-flexdll=%{flexdll:share}%" {flexdll:installed}
+
+    # Options
+    "--disable-warn-error"
+
+    "--enable-native-compiler" {!ocaml-option-bytecode-only:installed}
+    "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
+
+    "--with-afl" {ocaml-option-afl:installed}
+    "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+    "--enable-flambda" {ocaml-option-flambda:installed}
+    "--enable-frame-pointers" {ocaml-option-fp:installed}
+
+    "LIBS=-static" {ocaml-option-static:installed}
+
+    # Force use of cc for macOS and OpenBSD
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "ASPP=cc -c" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+
+    # Windows ports
+    "--build=x86_64-pc-cygwin" {os = "win32" & arch = "x86_64"}
+    "--build=i686-pc-cygwin" {os = "win32" & arch = "i686"}
+    # Fix on Cygwin
+    "--enable-imprecise-c99-float-ops" {os = "cygwin"}
+
+    "--host=i686-w64-mingw32" {ocaml-option-mingw:installed & ocaml-option-32bit:installed}
+    "--host=x86_64-w64-mingw32" {ocaml-option-mingw:installed & !ocaml-option-32bit:installed}
+    "--host=i686-pc-windows" {ocaml-option-msvc:installed & ocaml-option-32bit:installed}
+    "--host=x86_64-pc-windows" {ocaml-option-msvc:installed & !ocaml-option-32bit:installed}
+
+    # Compilation with musl
+    "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "CFLAGS=-Os" {ocaml-option-musl:installed}
+    "ASPP=musl-gcc -c" {ocaml-option-musl:installed & os-distribution!="alpine"}
+
+    # Compilation with sanitisers
+    "LDFLAGS=-Wl,--no-as-needed,-ldl" {ocaml-option-leak-sanitizer:installed | (ocaml-option-address-sanitizer:installed & os!="macos")}
+    "CC=gcc -ldl -fsanitize=leak -fno-omit-frame-pointer -O1 -g" {ocaml-option-leak-sanitizer:installed}
+    "CC=gcc -ldl -fsanitize=address -fno-omit-frame-pointer -O1 -g" {ocaml-option-address-sanitizer:installed & os!="macos"}
+    "CC=clang -fsanitize=address -fno-omit-frame-pointer -O1 -g" {ocaml-option-address-sanitizer:installed & os="macos"}
+
+    # 32-bit compilation (Linux)
+    "--host=i386-pc-linux-gnu" {ocaml-option-32bit:installed & os="linux"}
+    "CC=gcc -m32" {ocaml-option-32bit:installed & os="linux"}
+    "AS=as --32" {ocaml-option-32bit:installed & os="linux"}
+    "ASPP=gcc -m32 -c" {ocaml-option-32bit:installed & os="linux"}
+    "PARTIALLD=ld -r -melf_i386" {ocaml-option-32bit:installed & os="linux"}
+
+    # 32-bit compilation (macOS)
+    "--host=i386-apple-darwin" {ocaml-option-32bit:installed & os="macos"}
+    "CC=gcc -Wl,-read_only_relocs,suppress -arch i386 -m32" {ocaml-option-32bit:installed & os="macos"}
+    "AS=as -arch i386" {ocaml-option-32bit:installed & os="macos"}
+    "ASPP=gcc -arch i386 -m32 -c" {ocaml-option-32bit:installed & os="macos"}
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/5.1.0-beta1.tar.gz"
+}
+extra-files: ["ocaml-variants.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
+  {failure & jobs > 1}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
+]
+conflicts: [ "ocaml-option-fp" "ocaml-option-msvc" ]
+depopts: [
+  "ocaml-option-32bit"
+  "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
+  "ocaml-option-no-flat-float-array"
+  "ocaml-option-flambda"
+  "ocaml-option-musl"
+  "ocaml-option-leak-sanitizer"
+  "ocaml-option-address-sanitizer"
+  "ocaml-option-static"
+  "ocaml-option-mingw"
+  # TODO: the full behaviour for Cygwin _should_ be that if the Cygwin flexdll is installed and opam's flexdll is not requested,
+  #       then use it; if Cygwin's flexdll is _not_ installed then the opam flexdll package should be pulled in (4.13+) or the
+  #       depext system should cause flexdll to be installed (4.12 and earlier). If opam's flexdll is explicitly requested, then
+  #       OCaml should recompile with it.
+  "flexdll"
+]
+available: os = "win32" | os = "cygwin"


### PR DESCRIPTION
This PR mimicks the alpha2 package to support 5.1.0~beta1.

For comparison here's a diff of the two opam files:
```diff
3c3
< synopsis: "Second alpha release of OCaml 5.1.0, configure for Windows"
---
> synopsis: "First beta release of OCaml 5.1.0, configured for Windows"
8c8
< dev-repo: "git+https://github.com/ocaml/ocaml.git#5.0"
---
> dev-repo: "git+https://github.com/ocaml/ocaml.git#5.1"
16c16
<   "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64"}
---
>   "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv" }
92c92
<   src: "https://github.com/ocaml/ocaml/archive/5.1.0-alpha2.tar.gz"
---
>   src: "https://github.com/ocaml/ocaml/archive/5.1.0-beta1.tar.gz"
```